### PR TITLE
Fix celery in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - redis
     networks:
       - queue-network
+    volumes:
+      - ./app:/app/app
 
   redis:
     image: redis:alpine
@@ -53,4 +55,5 @@ volumes:
 
 networks:
   queue-network:
-    driver: bridge 
+    driver: bridge
+


### PR DESCRIPTION
I've got these messages before:

```
celery-1  | Usage: celery [OPTIONS] COMMAND [ARGS]...
celery-1  | Try 'celery --help' for help.
celery-1  | 
celery-1  | Error: Invalid value for '-A' / '--app': 
celery-1  | Unable to load celery application.
celery-1  | While trying to load the module app.queue_manager.celery_app the following error occurred:
celery-1  | Traceback (most recent call last):
celery-1  |   File "/usr/local/lib/python3.13/site-packages/celery/bin/celery.py", line 58, in convert
celery-1  |     return find_app(value)
celery-1  |   File "/usr/local/lib/python3.13/site-packages/celery/app/utils.py", line 383, in find_app
celery-1  |     sym = symbol_by_name(app, imp=imp)
celery-1  |   File "/usr/local/lib/python3.13/site-packages/kombu/utils/imports.py", line 59, in symbol_by_name
celery-1  |     module = imp(module_name, package=package, **kwargs)
celery-1  |   File "/usr/local/lib/python3.13/site-packages/celery/utils/imports.py", line 109, in import_from_cwd
celery-1  |     return imp(module, package=package)
celery-1  |   File "/usr/local/lib/python3.13/importlib/__init__.py", line 88, in import_module
celery-1  |     return _bootstrap._gcd_import(name[level:], package, level)
celery-1  |            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
celery-1  |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
celery-1  |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
celery-1  |   File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
celery-1  |   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
celery-1  |   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
celery-1  |   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
celery-1  |   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
celery-1  | ModuleNotFoundError: No module named 'app'
```